### PR TITLE
DM-9086 : implement test namespace and finalize_ hook framework

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN        useradd -d /home/flasker -m flasker
 RUN        mkdir /dist
 
 # Must run python setup.py sdist first.
-ARG        VERSION="0.0.1"
+ARG        VERSION="0.0.2"
 LABEL      version="$VERSION"
 COPY       dist/sqre-uservice-ccutter-$VERSION.tar.gz /dist
 RUN        pip install /dist/sqre-uservice-ccutter-$VERSION.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-"""Setuptools Script"""
+"""Setuptools script.
+"""
 import os
 import codecs
 from setuptools import setup, find_packages

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ DESCRIPTION = 'Bootstrapper for cookiecutter projects'
 AUTHOR = 'Adam Thornton'
 AUTHOR_EMAIL = 'athornton@lsst.org'
 URL = 'https://github.com/sqre-lsst/uservice-ccutter'
-VERSION = '0.0.1'
+VERSION = '0.0.2'
 LICENSE = 'MIT'
 
 

--- a/tests/test_substitute_technote.py
+++ b/tests/test_substitute_technote.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-"""Test substitution features for technotes"""
+"""Test substitution features for technotes.
+"""
 from copy import deepcopy
 from uservice_ccutter.plugins import substitute
 from uservice_ccutter.plugins.generic import current_year
@@ -32,7 +33,8 @@ TESTDATA = {
 
 
 def test_substitute_technote():
-    """Test field substitution for technotes."""
+    """Test field substitution for technotes.
+    """
     testdict = deepcopy(TESTDATA)
     substitute("lsst-technote-bootstrap", None, testdict)
     changed = ["github_org", "copyright_year"]

--- a/tests/test_substitute_uservice.py
+++ b/tests/test_substitute_uservice.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-"""Test substitution features for microservice"""
+"""Test substitution features for microservice.
+"""
 from copy import deepcopy
 from uservice_ccutter.plugins import substitute
 from uservice_ccutter.plugins.generic import current_year
@@ -19,7 +20,8 @@ TESTDATA = {
 
 
 def test_substitute_technote():
-    """Test field substitution for microservices."""
+    """Test field substitution for microservices.
+    """
     testdict = deepcopy(TESTDATA)
     substitute("uservice-bootstrap", None, testdict)
     changed = ["year"]

--- a/uservice_ccutter/__init__.py
+++ b/uservice_ccutter/__init__.py
@@ -1,4 +1,5 @@
-"""SQuaRE ccutter proxy (api.lsst.codes-compliant)"""
+"""SQuaRE cookiecutter service (api.lsst.codes-compliant).
+"""
 from .server import server, standalone
 from .projecturls import PROJECTURLS
 __all__ = ["server", "standalone", "PROJECTURLS"]

--- a/uservice_ccutter/plugins/__init__.py
+++ b/uservice_ccutter/plugins/__init__.py
@@ -1,4 +1,5 @@
 """Plugins for the Cookiecutter make-me-a-thing service"""
+# Actual project types live in the projecttypes directory.
 from .finalize import finalize
 from .substitute import substitute
 __all__ = ["finalize", "substitute"]

--- a/uservice_ccutter/plugins/__init__.py
+++ b/uservice_ccutter/plugins/__init__.py
@@ -1,3 +1,4 @@
 """Plugins for the Cookiecutter make-me-a-thing service"""
+from .finalize import finalize
 from .substitute import substitute
-__all__ = ["substitute"]
+__all__ = ["finalize", "substitute"]

--- a/uservice_ccutter/plugins/finalize.py
+++ b/uservice_ccutter/plugins/finalize.py
@@ -1,12 +1,14 @@
 """Delegate things-to-do-after-creating-repository to particular project-type
-hooks."""
+hooks.
+"""
 from .load_plugin import load_plugin
 
 
 def finalize(templatetype, auth, inputdict):
     """Dispatch to particular type's finalize_ (note trailing underscore;
     the theory is that your actual fields won't end with one) method, if
-    it exists.  No-op if it doesn't."""
+    it exists.  No-op if it doesn't.
+    """
     module = load_plugin(templatetype)
     fname = "finalize_"
     if fname in module.__dict__:

--- a/uservice_ccutter/plugins/finalize.py
+++ b/uservice_ccutter/plugins/finalize.py
@@ -1,0 +1,13 @@
+"""Delegate things-to-do-after-creating-repository to particular project-type
+hooks."""
+from .load_plugin import load_plugin
+
+
+def finalize(templatetype, auth, inputdict):
+    """Dispatch to particular type's finalize_ (note trailing underscore;
+    the theory is that your actual fields won't end with one) method, if
+    it exists.  No-op if it doesn't."""
+    module = load_plugin(templatetype)
+    fname = "finalize_"
+    if fname in module.__dict__:
+        getattr(module, fname)(auth, inputdict)

--- a/uservice_ccutter/plugins/load_plugin.py
+++ b/uservice_ccutter/plugins/load_plugin.py
@@ -1,0 +1,30 @@
+"""Load a plugin module by name"""
+import importlib
+import sys
+from apikit import BackendError
+try:
+    from importlib import ModuleNotFoundError
+except ImportError:
+    ModuleNotFoundError = ImportError
+
+
+def load_plugin(plugin_name):
+    """Load a named plugin.  Substitute "-" with "_" first.  If the module
+    is already loaded, return it; if not, load it and then return the
+    loaded module."""
+    ctt = "." + plugin_name.lower().replace("-", "_")
+    ctr = ".".join(__name__.split(".")[:-1])
+    modname = ctr + ctt
+    mod = None
+    try:
+        mod = sys.modules[modname]
+    except KeyError:
+        try:
+            importlib.import_module(ctt, package=ctr)
+        except ModuleNotFoundError as exc:
+            raise BackendError(status_code=500,
+                               reason="Internal Server Error",
+                               content="Could not load plugin '%s': %s" %
+                               (plugin_name, str(exc)))
+        mod = sys.modules[modname]
+    return mod

--- a/uservice_ccutter/plugins/load_plugin.py
+++ b/uservice_ccutter/plugins/load_plugin.py
@@ -1,4 +1,5 @@
-"""Load a plugin module by name"""
+"""Load a plugin module by name.
+"""
 import importlib
 import sys
 from apikit import BackendError
@@ -11,16 +12,18 @@ except ImportError:
 def load_plugin(plugin_name):
     """Load a named plugin.  Substitute "-" with "_" first.  If the module
     is already loaded, return it; if not, load it and then return the
-    loaded module."""
-    ctt = "." + plugin_name.lower().replace("-", "_")
-    ctr = ".".join(__name__.split(".")[:-1])
-    modname = ctr + ctt
-    mod = None
+    loaded module.
+    """
+    project_type = "." + plugin_name.lower().replace("-", "_")
+    module_path = ".".join(__name__.split(".")[:-1]) + ".projecttypes"
+    if module_path not in sys.modules:
+        importlib.import_module(module_path)
+    modname = module_path + project_type
     try:
         mod = sys.modules[modname]
     except KeyError:
         try:
-            importlib.import_module(ctt, package=ctr)
+            importlib.import_module(project_type, package=module_path)
         except ModuleNotFoundError as exc:
             raise BackendError(status_code=500,
                                reason="Internal Server Error",

--- a/uservice_ccutter/plugins/lsst_technote_bootstrap.py
+++ b/uservice_ccutter/plugins/lsst_technote_bootstrap.py
@@ -15,7 +15,8 @@ from .generic import current_year
 ORGSERIESMAP = {"sqr": "lsst-sqre",
                 "dmtn": "lsst-dm",
                 "smtn": "lsst-sims",
-                "ldm": "lsst"}
+                "ldm": "lsst",
+                "test": "lsst-sqre"}
 
 
 def serial_number(auth, inputdict):

--- a/uservice_ccutter/plugins/lsst_technote_bootstrap.py
+++ b/uservice_ccutter/plugins/lsst_technote_bootstrap.py
@@ -90,3 +90,8 @@ def first_author(auth, inputdict):
     if "github_email" not in inputdict or not inputdict["github_email"]:
         inputdict["github_email"] = "sqrbot@lsst.org"
     return inputdict["first_author"]
+
+
+def finalize_(auth, inputdict):
+    """Register with Keeper."""
+    pass

--- a/uservice_ccutter/plugins/projecttypes/generic.py
+++ b/uservice_ccutter/plugins/projecttypes/generic.py
@@ -1,4 +1,5 @@
-"""Generic utility substitution functions used by multiple plugins"""
+"""Generic utility substitution functions used by multiple plugins.
+"""
 import datetime
 
 

--- a/uservice_ccutter/plugins/projecttypes/lsst_technote_bootstrap.py
+++ b/uservice_ccutter/plugins/projecttypes/lsst_technote_bootstrap.py
@@ -20,7 +20,8 @@ ORGSERIESMAP = {"sqr": "lsst-sqre",
 
 
 def serial_number(auth, inputdict):
-    """Find the next available serial number for the specified series."""
+    """Find the next available serial number for the specified series.
+    """
     series = inputdict["series"].lower()
     # Requires that the series pick list has already been replaced with a
     #  string.
@@ -74,17 +75,20 @@ def serial_number(auth, inputdict):
 
 
 def github_org(auth, inputdict):
-    """Derive GitHub Org from the series."""
+    """Derive GitHub Org from the series.
+    """
     return ORGSERIESMAP[inputdict["series"].lower()]
 
 
 def copyright_year(auth, inputdict):
-    """Replace copyright_year with current year."""
+    """Replace copyright_year with current year.
+    """
     return current_year()
 
 
 def first_author(auth, inputdict):
-    """Set canonical GH fields for project creation."""
+    """Set canonical GH fields for project creation.
+    """
     if "github_name" not in inputdict or not inputdict["github_name"]:
         inputdict["github_name"] = inputdict["first_author"]
     # And since we don't currently have email....
@@ -94,5 +98,6 @@ def first_author(auth, inputdict):
 
 
 def finalize_(auth, inputdict):
-    """Register with Keeper."""
+    """Register with Keeper.
+    """
     pass

--- a/uservice_ccutter/plugins/projecttypes/uservice_bootstrap.py
+++ b/uservice_ccutter/plugins/projecttypes/uservice_bootstrap.py
@@ -11,14 +11,16 @@ from .generic import current_year
 
 
 def year(auth, inputdict):
-    """Replace year with current year."""
+    """Replace year with current year.
+    """
     inputdict = inputdict
     auth = auth
     return current_year()
 
 
 def author_name(auth, inputdict):
-    """Set canonical GH author field for project creation."""
+    """Set canonical GH author field for project creation.
+    """
     auth = auth
     if "github_name" not in inputdict or not inputdict["github_email"]:
         inputdict["github_name"] = inputdict["author_name"]
@@ -26,7 +28,8 @@ def author_name(auth, inputdict):
 
 
 def email(auth, inputdict):
-    """Set canonical GH email field for project creation."""
+    """Set canonical GH email field for project creation.
+    """
     auth = auth
     if "github_email" not in inputdict or not inputdict["github_email"]:
         inputdict["github_email"] = inputdict["email"]
@@ -34,7 +37,8 @@ def email(auth, inputdict):
 
 
 def svc_name(auth, inputdict):
-    """Derive github_repo from svc_name."""
+    """Derive github_repo from svc_name.
+    """
     auth = auth
     # This happens before Jinja2 template substitution.
     if "github_repo" not in inputdict or not inputdict["github_repo"]:

--- a/uservice_ccutter/plugins/substitute.py
+++ b/uservice_ccutter/plugins/substitute.py
@@ -1,4 +1,5 @@
-"""Substitute values in incoming data"""
+"""Substitute values in incoming data by field.
+"""
 from .load_plugin import load_plugin
 
 
@@ -13,10 +14,10 @@ def substitute(templatetype, auth, inputdict):
     github_repo.  Those will be used to create the remote repository at
     GitHub.  That does imply that any template whatsoever must have at least
     one field that's guaranteed to be present so that we can use its hook to
-    drive creation of the github_* fields."""
+    drive creation of the github_* fields.
+    """
     module = load_plugin(templatetype)
-    symbols = [x for x in module.__dict__ if x[0] != "_"
-               and x != "finalize_"]
+    symbols = [x for x in module.__dict__ if x[0] != "_" and x[-1] != "_"]
     flist = list(inputdict.keys())
     # Can't iterate over inputdict while mutating it.
     #  However, new fields we add won't be on the change-me list.

--- a/uservice_ccutter/plugins/substitute.py
+++ b/uservice_ccutter/plugins/substitute.py
@@ -1,6 +1,5 @@
 """Substitute values in incoming data"""
-import importlib
-import sys
+from .load_plugin import load_plugin
 
 
 def substitute(templatetype, auth, inputdict):
@@ -15,15 +14,12 @@ def substitute(templatetype, auth, inputdict):
     GitHub.  That does imply that any template whatsoever must have at least
     one field that's guaranteed to be present so that we can use its hook to
     drive creation of the github_* fields."""
-    ctt = "." + templatetype.lower().replace("-", "_")
-    ctr = ".".join(__name__.split(".")[:-1])
-    importlib.import_module(ctt, package=ctr)
-    modname = ctr + ctt
-    symbols = [x for x in sys.modules[modname].__dict__ if x[0] != "_"]
+    module = load_plugin(templatetype)
+    symbols = [x for x in module.__dict__ if x[0] != "_"
+               and x != "finalize_"]
     flist = list(inputdict.keys())
     # Can't iterate over inputdict while mutating it.
     #  However, new fields we add won't be on the change-me list.
     for fld in flist:
         if fld in symbols:
-            inputdict[fld] = getattr(sys.modules[modname], fld)(auth,
-                                                                inputdict)
+            inputdict[fld] = getattr(module, fld)(auth, inputdict)

--- a/uservice_ccutter/projecturls.py
+++ b/uservice_ccutter/projecturls.py
@@ -1,2 +1,4 @@
+"""GitHub URLs for each project type.
+"""
 PROJECTURLS = ["https://github.com/lsst-sqre/lsst-technote-bootstrap",
                "https://github.com/lsst-sqre/uservice-bootstrap"]

--- a/uservice_ccutter/server.py
+++ b/uservice_ccutter/server.py
@@ -22,7 +22,7 @@ from codekit.codetools import TempDir, get_git_credential_helper
 from cookiecutter.main import cookiecutter
 from cookiecutter.exceptions import CookiecutterException
 from flask import jsonify, request
-from .plugins import substitute
+from .plugins import substitute, finalize
 from .projecturls import PROJECTURLS
 
 
@@ -31,7 +31,7 @@ def server(run_standalone=False):
     # Add "/ccutter" for mapping behind api.lsst.codes
     with TempDir() as temp_dir:
         app = APIFlask(name="uservice-ccutter",
-                       version="0.0.1",
+                       version="0.0.2",
                        repository="https://github.com/sqre-lsst/" +
                        "uservice-ccutter",
                        description="Bootstrapper for cookiecutter projects",
@@ -99,6 +99,7 @@ def server(run_standalone=False):
             # Here's the magic.
             substitute(ptype, auth, userdict)
             retval = create_project(ptype, auth, userdict)
+            finalize(ptype, auth, userdict)
             return jsonify(retval)
 
         # pylint: disable=too-many-locals

--- a/uservice_ccutter/server.py
+++ b/uservice_ccutter/server.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-"""ccutter microservice framework"""
+"""Cookiecutter microservice framework.
+"""
 import json
 import os
 import os.path
@@ -27,7 +28,8 @@ from .projecturls import PROJECTURLS
 
 
 def server(run_standalone=False):
-    """Create the app and then run it."""
+    """Create the app and then run it.
+    """
     # Add "/ccutter" for mapping behind api.lsst.codes
     with TempDir() as temp_dir:
         app = APIFlask(name="uservice-ccutter",
@@ -56,14 +58,16 @@ def server(run_standalone=False):
         @app.route("/")
         # pylint: disable=unused-variable
         def healthcheck():
-            """Default route to keep Ingress controller happy."""
+            """Default route to keep Ingress controller happy.
+            """
             return "OK"
 
         @app.route("/ccutter")
         @app.route("/ccutter/")
         # pylint: disable=unused-variable
         def display_project_types():
-            """Return cookiecutter.json for each project type"""
+            """Return cookiecutter.json for each project type.
+            """
             retval = {}
             for ptype in app.config["PROJECTTYPE"]:
                 retval[ptype] = get_single_project_type(ptype)
@@ -73,13 +77,15 @@ def server(run_standalone=False):
         @app.route("/ccutter/<ptype>/", methods=["GET", "POST"])
         # pylint: disable=unused-variable
         def action_for_type(ptype):
-            """Either return the template, or create a new thing"""
+            """Either return the template, or create a new thing.
+            """
             if request.method == "GET":
                 return jsonify(get_single_project_type(ptype))
             return post_request(ptype)
 
         def post_request(ptype):
-            """Create project: write to local repo and to GH."""
+            """Create project: write to local repo and to GitHub.
+            """
             # Now we're POSTing.
             # We need authorization to POST.  Raise error if not.
             check_authorization()
@@ -104,7 +110,8 @@ def server(run_standalone=False):
 
         # pylint: disable=too-many-locals
         def create_project(ptype, auth, userdict):
-            """Create the project"""
+            """Create the project.
+            """
             cloneurl = app.config["PROJECTTYPE"][ptype]["cloneurl"]
             with TempDir() as workdir:
                 clonedir = workdir + "/clonesrc"
@@ -181,7 +188,8 @@ def server(run_standalone=False):
                 return retdict
 
         def create_github_repository(auth, userdict):
-            """Create new repo at GH."""
+            """Create new repo at GitHub.
+            """
             ghub = github3.login(auth["username"], token=auth["password"])
             try:
                 ghub.me()
@@ -213,7 +221,8 @@ def server(run_standalone=False):
             return repo.clone_url
 
         def get_single_project_type(ptype):
-            """Return a single project type's cookiecutter.json."""
+            """Return a single project type's cookiecutter.json.
+            """
             if ptype not in app.config["PROJECTTYPE"]:
                 types = [x for x in app.config["PROJECTTYPE"]]
                 raise BackendError(status_code=400,
@@ -224,7 +233,8 @@ def server(run_standalone=False):
 
         def check_authorization():
             """Sets app.auth["data"] if credentials provided, raises an
-            error otherwise."""
+            error otherwise.
+            """
             iauth = request.authorization
             if iauth is None:
                 raise BackendError(reason="Unauthorized",
@@ -238,12 +248,14 @@ def server(run_standalone=False):
 
 
 def standalone():
-    """Entry point for running as its own executable."""
+    """Entry point for running as its own executable.
+    """
     server(run_standalone=True)
 
 
 def _refresh_cache(app, temp_dir, timeout):
-    """Refresh cookiecutter.json cache if needed."""
+    """Refresh cookiecutter.json cache if needed.
+    """
     # pylint: disable=too-many-locals
     ref = temp_dir + "/last_refresh"
     now = int(time.time())


### PR DESCRIPTION
This lays the groundwork for the stuff I am about to do with taking Jonathan out of the technote loop.

One is that we now have a "test" series so I am not polluting the real namespace as we flail around.

Two is that I've broken the plugin-loading functionality out into its own function and added a finalize_ function.  That will be the hook we use to make technote post-commit processing (e.g. registering with keeper) work.

Three, this clearly deserves a version bump.

I want to do this as a separate PR now so that I can roll out this to api.lsst.codes, so we can call it and get new test technotes in lsst-sqre.  