### PR TITLE
Don't run under uwsgi: breaks on Centos7: tickets/DM-9285

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,7 @@ USER       uwsgi
 WORKDIR    /home/uwsgi
 COPY	   uwsgi.ini .
 EXPOSE     5000
-CMD        [ "uwsgi", "-T", "uwsgi.ini" ]
+#CMD        [ "uwsgi", "-T", "uwsgi.ini" ]
+# uWSGI doesn't play nice with cookiecutter.
+CMD	   [ "sqre-uservice-ccutter" ]
+

--- a/uservice_ccutter/plugins/projecttypes/lsst_technote_bootstrap.py
+++ b/uservice_ccutter/plugins/projecttypes/lsst_technote_bootstrap.py
@@ -43,7 +43,7 @@ def serial_number(auth, inputdict):
     ghub = github3.login(auth["username"], token=auth["password"])
     try:
         ghub.me()
-    except github3.exceptions.AuthenticationFailed:
+    except (github3.exceptions.AuthenticationFailed, AttributeError):
         raise BackendError(status_code=401,
                            reason="Bad credentials",
                            content="GitHub login failed.")

--- a/uservice_ccutter/server.py
+++ b/uservice_ccutter/server.py
@@ -215,7 +215,7 @@ def server(run_standalone=False):
         ghub = github3.login(auth["username"], token=auth["password"])
         try:
             ghub.me()
-        except github3.exceptions.AuthenticationFailed:
+        except (github3.exceptions.AuthenticationFailed, AttributeError):
             raise BackendError(status_code=401,
                                reason="Bad credentials",
                                content="GitHub login failed.")


### PR DESCRIPTION

If the GitHub handle is None, treat it as an authentication error.